### PR TITLE
Refactor to meet standardised Terraform structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ The underutilisation of nodes is determined by a configurable `threshold` thresh
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >=3.0.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >=2.6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_helm"></a> [helm](#provider\_helm) | n/a |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >=2.6.0 |
 
 ## Modules
 

--- a/main.tf
+++ b/main.tf
@@ -1,15 +1,15 @@
 locals {
-    deschduler-version = "v0.23.1"
+  deschduler-version = "v0.23.1"
 }
 
 resource "helm_release" "descheduler" {
-    name       = "descheduler"
-    repository = "https://kubernetes-sigs.github.io/descheduler/"
-    chart      = "descheduler"
-    namespace  = "kube-system"
-    version    = local.deschduler-version
+  name       = "descheduler"
+  repository = "https://kubernetes-sigs.github.io/descheduler/"
+  chart      = "descheduler"
+  namespace  = "kube-system"
+  version    = local.deschduler-version
 
-values = [templatefile("${path.module}/templates/descheduler.yaml.tpl", {
+  values = [templatefile("${path.module}/templates/descheduler.yaml.tpl", {
     descheduler_version = local.deschduler-version
-    })]
+  })]
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,13 +1,9 @@
 terraform {
   required_version = ">= 0.14"
   required_providers {
-    aws = {
-      source = "hashicorp/aws"
-      version = ">=3.0.0"
-    }
     helm = {
-      source = "hashicorp/helm"
-      
+      source  = "hashicorp/helm"
+      version = ">=2.6.0"
     }
   }
 }


### PR DESCRIPTION
This PR:

- runs `terraform fmt`
- removes the unused `aws` provider
- pins the `helm` provider 