### PR TITLE
Fix descheduler module version #4427

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  deschduler-version = "v0.23.1"
+  descheduler-version = "0.23.1"
 }
 
 resource "helm_release" "descheduler" {
@@ -7,9 +7,7 @@ resource "helm_release" "descheduler" {
   repository = "https://kubernetes-sigs.github.io/descheduler/"
   chart      = "descheduler"
   namespace  = "kube-system"
-  version    = local.deschduler-version
+  version    = local.descheduler-version
 
-  values = [templatefile("${path.module}/templates/descheduler.yaml.tpl", {
-    descheduler_version = local.deschduler-version
-  })]
+  values = templatefile("${path.module}/templates/descheduler.yaml.tpl")
 }

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,6 @@ resource "helm_release" "descheduler" {
   namespace  = "kube-system"
   version    = local.descheduler-version
 
-  values = [
-    "${path.module}/templates/descheduler.yaml.tpl"
-  ]
+    values = [templatefile("${path.module}/templates/descheduler.yaml.tpl", {
+  })]
 }

--- a/main.tf
+++ b/main.tf
@@ -9,5 +9,7 @@ resource "helm_release" "descheduler" {
   namespace  = "kube-system"
   version    = local.descheduler-version
 
-  values = templatefile("${path.module}/templates/descheduler.yaml.tpl")
+  values = [
+    "${path.module}/templates/descheduler.yaml.tpl"
+  ]
 }

--- a/templates/descheduler.yaml.tpl
+++ b/templates/descheduler.yaml.tpl
@@ -8,7 +8,7 @@ kind: Deployment
 image:
   repository: k8s.gcr.io/descheduler/descheduler
   # Overrides the image tag whose default is the chart version
-  tag: ${descheduler_version}
+  tag:
   pullPolicy: IfNotPresent
 
 imagePullSecrets:

--- a/templates/descheduler.yaml.tpl
+++ b/templates/descheduler.yaml.tpl
@@ -8,7 +8,7 @@ kind: Deployment
 image:
   repository: k8s.gcr.io/descheduler/descheduler
   # Overrides the image tag whose default is the chart version
-  tag:
+  # tag:
   pullPolicy: IfNotPresent
 
 imagePullSecrets:


### PR DESCRIPTION
This PR addresses terraform sometimes detecting an update required for descheduler due to version syntax in the Helm release:
```
# module.descheduler.helm_release.descheduler will be updated in-place
  ~ resource "helm_release" "descheduler" {
        id                         = "descheduler"
        name                       = "descheduler"
      ~ version                    = "0.23.1" -> "v0.23.1"
```