### PR TITLE
bump chart version and registry

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  descheduler-version = "0.23.1"
+  descheduler-version = "0.24.1"
 }
 
 resource "helm_release" "descheduler" {

--- a/templates/descheduler.yaml.tpl
+++ b/templates/descheduler.yaml.tpl
@@ -6,7 +6,7 @@
 kind: Deployment
 
 image:
-  repository: k8s.gcr.io/descheduler/descheduler
+  repository: registry.k8s.io/descheduler/descheduler
   # Overrides the image tag whose default is the chart version
   # tag:
   pullPolicy: IfNotPresent


### PR DESCRIPTION
As per:
https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/gh/ministryofjustice/cloud-platform/4875