### PR TITLE
update helm release

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  descheduler-version = "0.24.1"
+  descheduler-version = "0.26.1"
 }
 
 resource "helm_release" "descheduler" {


### PR DESCRIPTION
Following EKS 1.25 upgrade, bumping release  as per [compatibility matrix guidelines](https://github.com/kubernetes-sigs/descheduler#compatibility-matrix)