### PR TITLE
chore: 🤖 update helm release to 0.31.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 locals {
-  descheduler-version = "0.29.0"
+  descheduler-version = "0.31.0"
 }
 
 resource "helm_release" "descheduler" {


### PR DESCRIPTION
this updates and provides tested support for k8s 1.29 > 1.31 [see matrix](https://github.com/kubernetes-sigs/descheduler?tab=readme-ov-file#compatibility-matrix)

relates to ministryofjustice/cloud-platform#6509