### PR TITLE
Increase memory thresholds and targetThresholds

### DIFF
--- a/templates/descheduler.yaml.tpl
+++ b/templates/descheduler.yaml.tpl
@@ -80,11 +80,11 @@ deschedulerPolicy:
         args:
           thresholds:
             cpu: 70
-            memory: 70
+            memory: 72
             pods: 75
           targetThresholds:
             cpu: 85
-            memory: 80
+            memory: 82
             pods: 90
       - name: HighNodeUtilization
         args:


### PR DESCRIPTION
Identify more nodes as underutilised so more pods get evicted by:
Increasing LowNodeUtilization thresholds to 72
Increaseing LowNodeUtilization targetThresholds to 82
